### PR TITLE
Add password input to GUI and authentication flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+outputs/
+*.pyc
+.icloud_session.json
+.venv_macos/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,79 @@
-# iCloud
+# iCloud Multi-Agent Helper
+
+This repository hosts a **mock** implementation of the multi-agent architecture described in
+`agents.md`. It demonstrates how independent agents collaborate to authenticate, discover iCloud
+(backed by fixtures), plan downloads, copy data, and produce verification reports.
+
+> ⚠️ **Important:** Apple does not provide a supported public API for downloading full iCloud device
+> backups. The implementation here keeps those capabilities behind a policy gate and uses mock data
+> only. To work with real backups you must integrate a compliant data source (e.g. Finder/iTunes USB
+> backups) or accept the risks of private endpoints.
+
+## Getting Started
+
+1. Ensure Python 3.11+ is available.
+2. Install the project in editable mode (optional):
+
+   ```bash
+   pip install -e .
+   ```
+
+3. Inspect the mock dataset in `data/mock_icloud.json`.
+4. Run the CLI:
+
+   ```bash
+   python -m icloud_multi_agent.cli --help
+   ```
+
+5. Launch the GUI (optional):
+
+   ```bash
+   python -m icloud_multi_agent.gui
+   ```
+
+   The window lets you configure whether private endpoints are allowed, browse to a mock data
+   source, authenticate with your Apple ID credentials (email + password + 2FA code), refresh the
+   backup list, and trigger downloads into a local directory.
+
+## macOS One-Click Launcher
+
+For macOS users the repository ships with `macos-launcher.command`. Double-clicking this file from
+Finder (or running `open macos-launcher.command` from Terminal) will:
+
+1. Verify that you are on macOS and locate `python3` (3.11+).
+2. Create a dedicated virtual environment under `.venv_macos/` on the first run.
+3. Install or update the project in editable mode inside that environment.
+4. Start the Tkinter GUI once setup completes.
+
+If `python3` cannot be found the launcher prints guidance for installing it from python.org. You can
+pass additional arguments to the GUI (for example, `--allow-private`) by editing the command to call
+`open macos-launcher.command --args --allow-private`. The script keeps the Terminal window open at
+the end so you can review any messages or errors before closing.
+
+## Example Workflow
+
+```bash
+# Authenticate (stores a mock session under ~/.icloud_session.json)
+python -m icloud_multi_agent.cli --allow-private auth-login --apple-id user@example.com --code 000000
+
+# The CLI will securely prompt for the Apple ID password unless you pass --password explicitly.
+
+# List available backups (requires --allow-private)
+python -m icloud_multi_agent.cli --allow-private backup-list
+
+# Download the chosen backup into ./outputs/icloud_backups
+python -m icloud_multi_agent.cli --allow-private backup-download --id demo-backup
+```
+
+The download command will produce:
+
+- A copied folder structure under `outputs/icloud_backups`.
+- Integrity logs in `outputs/logs/session.jsonl`.
+- A JSON report in `outputs/icloud_backups/reports`.
+
+## Extending to Real Sources
+
+- Replace `MockICloudAPI` with an adapter that interfaces with an approved source (USB backups,
+  iCloud Drive files, etc.).
+- Implement stronger verification in `HashVerifier`, e.g. by comparing to manifest hashes.
+- Extend the CLI/GUI to integrate with additional storage providers or richer verification flows.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,204 @@
+# Codex — **agents.md**
+
+> **Amaç:** iCloud hesabına oturum açıp **mevcut iOS cihaz yedeklerini** (iCloud Backups) *listeleyen*, kullanıcıya seçim yaptırıp **bilgisayara güvenli şekilde indiren** bir yardımcı programı, çok‑ajanlı (multi‑agent) mimariyle üretmek.
+
+> **Kritik Not (Gerçekçilik ve Sınırlar):** Apple, **iCloud cihaz yedeklerini indirmek için resmi/genel bir API sunmaz**. iCloud.com ve iCloud for Windows **cihaz yedeği** (MobileBackup) dosyalarını doğrudan vermez; genellikle **yalnızca fotoğraflar, Drive dosyaları, notlar vs.** erişilebilir. Cihaz yedeğini *programatik* indirme, **özel/ters‑mühendislik** edilmiş uç noktalar ya da 3P araçlarla yapılır ve **hesap güvenliği ile kullanım şartlarına** takılabilir.
+>
+> **Güvenli ve uygulanabilir yaklaşımlar:**
+>
+> 1. **USB üstünden yerel yedek** (Finder/iTunes) — Resmi, stabil. (iCloud’dan değil; ama cihaz yedeğini indirilebilir hale getirir.)
+> 2. **iCloud for Windows** + **MobileBackup klasörü yakalama** — Bazı senaryolarda ".mbdb/.mbdx" eşdeğerleri ve dosya parçaları lokal cache’e gelir; garanti değil.
+> 3. **3P/Topluluk projeleri** (örn. *pyicloud* yalnızca Foto/Drive, **cihaz yedeği değil**). Özel API kullanan araçlar **hesap riski** doğurur.
+>
+> Bu belge, **Ajan tasarımı** ve **akış**ı tanımlar; gerçek indirme yeteneği, seçilen yaklaşımın teknik/etik kısıtlarına bağlıdır.
+
+---
+
+## 0) Hedefler
+
+- iCloud hesabına güvenli kimlik doğrulama (Apple ID, 2FA, SRP/"Trust this browser").
+- Kullanıcıya **mevcut yedek(ler)i** ve **cihaz/ tarih** bilgilerini gösterme.
+- Seçilen yedeğin **indirilebilir içeriklerini** (mümkünse) **parçalı/kalıcı** (resumable) şekilde indirme.
+- **Hash doğrulama**, **şifreli yedek** ise kullanıcı parolası ile **decrypt & verify**.
+- İndirilen içeriği **klasör yapısına** yerleştirme, **disk kota/boş alan** kontrolü, **log & rapor**.
+
+## 1) Mimari Genel Bakış (Multi‑Agent)
+
+```
+┌─────────────────┐     ┌────────────────────┐     ┌──────────────────────┐
+│ UI/Orchestrator │◄──► │  Auth & 2FA Agent  │◄──►│   iCloud API Agent    │
+└─────────────────┘     └────────────────────┘     └──────────────────────┘
+         │                          │                          │
+         ▼                          ▼                          ▼
+┌──────────────────────┐   ┌────────────────────┐      ┌───────────────────┐
+│ Backup Indexer Agent │   │ Download Manager   │      │ Crypto/Verify     │
+└──────────────────────┘   └────────────────────┘      └───────────────────┘
+         │                          │                          │
+         ▼                          ▼                          ▼
+┌───────────────────────┐  ┌──────────────────────┐   ┌─────────────────────┐
+│ Storage/Quota Manager │  │ Integrity/Resume Log │   │ Report/Export Agent │
+└───────────────────────┘  └──────────────────────┘   └─────────────────────┘
+```
+
+### 1.1 Ajanların Sorumlulukları
+
+- **UI/Orchestrator**: Komut satırı/GUI; akışları tetikler, hata/geri kazanım stratejisini yönetir.
+- **Auth & 2FA Agent**: Apple ID oturum, 2FA (SMS/Push/Kod), "Trust this browser" token’larının güvenli saklanması.
+- **iCloud API Agent**: Seçilen yönteme göre iCloud kaynaklarını listeler (resmi erişilebilenler: Foto/Drive vs.); *cihaz yedeği* için özel uç noktalar seçilecekse **policy‑gate** uygular.
+- **Backup Indexer Agent**: Ulaşılabilen yedeklerin **meta verisini çıkarır** (cihaz adı, iOS sürümü, tarih, yaklaşık boyut). *Not:* Bu, yönteme bağlı olarak **tam görünmeyebilir**.
+- **Download Manager**: Parçalı indirme (range), **retries**, **checksum**, **resume**. Hız/kota/lokal disk yönetimi ile entegre.
+- **Crypto/Verify**: Şifreli yedekler için parola ile **PBKDF**/Keybag çözümü (uygunsa), SHA‑256/xxhash doğrulama.
+- **Storage/Quota Manager**: Boş alan, hedef dizin, dosya sistemi sınırları (NTFS uzun path, case sensitivity vs.).
+- **Integrity/Resume Log**: JSONL/SQLite; hangi parçalar indi, hash’ler, son durum, tekrar başlatma.
+- **Report/Export Agent**: Özet rapor (HTML/Markdown/JSON), log paketleme, hatalı parça listesi.
+
+## 2) Politikalar ve Güvenlik
+
+- **Kullanım Şartları Uyum**: Apple TOS ihlali riskine karşı **varsayılan olarak yalnızca resmi destekli akışlar** (*USB local backup* ya da iCloud içindeki **resmi erişilebilen veri sınıfları**) etkin.
+- **Policy Gate**: Kullanıcı özel API modunu açmadan, cihaz yedeklerine erişmeye çalışılmaz. Açılırsa uyarı metni ve risk onayı gerekir.
+- **Gizli Bilgiler**: `APPLE_ID`, `APP_SPECIFIC_PASSWORD` (gerekirse), 2FA tokenları, keychain benzeri kasada **OS‑safe** saklanır (Windows DPAPI, macOS Keychain).
+- **Kayıtlar**: Hassas veriler log’a maskelenir. PII redaksiyon kuralları.
+
+## 3) Kurulum / Ortam
+
+- **OS**: Windows 10/11, macOS 12+ (USB local backup için macOS daha doğal).
+- **Bağımlılıklar**:
+  - Resmi akış: `iTunes/Finder` (USB backup), `Apple Mobile Device Support`.
+  - iCloud içeriği (Foto/Drive) için: `iCloud for Windows` / macOS iCloud.
+  - Opsiyonel: `pyicloud` (yalnızca Foto/Drive) \* cihaz yedeği değil.
+  - Hash: `xxhash`, `openssl`/`cryptography`.
+  - CLI/UI: `Python 3.11+`, `rich`/`textual` (CLI) veya `PySide6` (GUI).
+
+## 4) Yapılandırma (ENV)
+
+```
+ICLOUD_REGION=default
+DOWNLOAD_DIR=./outputs/icloud_backups
+CHUNK_SIZE_MB=16
+MAX_PARALLEL=4
+HASH_ALGO=sha256
+ALLOW_PRIVATE_ENDPOINTS=false
+LOG_LEVEL=INFO
+```
+
+Mac/Win için gizli bilgiler **OS kasasında** tutulur; `.env` içine yazılmaz.
+
+## 5) Kullanım Akışı
+
+1. **Giriş**: UI → Apple ID girilir. Ajan 2FA isteğini yakalar.
+2. **2FA**: Kod/Push doğrulanır, "Trust" token alınır ve kasaya yazılır.
+3. **Yedek Keşfi**:
+   - **Resmi**: USB bağla → yerel backup listesi çıkar → seç → kopyala/doğrula.
+   - **iCloud İçeriği (resmi)**: Foto/Drive klasörleri listelenir ve indirilebilir.
+   - **Özel (opsiyonel)**: *Policy‑gate* onaylı → iCloud **Device Backups** meta denemesi → dönen listeye göre devam.
+4. **Seçim & Plan**: Hedef dizin, tahmini boyut, boş alan → **Quota check**.
+5. **İndirme**: Parçalı, tekrar başlatılabilir. Her parça hash’lenir.
+6. **Doğrulama**: Toplam hash, opsiyonel decrypt/parse (şifreli yedekse ve bilgi varsa).
+7. **Rapor**: HTML/MD/JSON özet + CSV log.
+
+## 6) Komutlar (CLI taslak)
+
+```
+# İlk giriş ve trust
+codex-icloud auth login --apple-id user@example.com
+
+# USB yerel yedekleri listele
+codex-icloud backup list --source usb
+
+# (Opsiyonel, riskli) iCloud cihaz yedekleri listele
+codex-icloud backup list --source icloud --allow-private
+
+# Seçileni indir
+codex-icloud backup download --id <backup_id> \
+  --dest "D:/Backups/iPhone_13_2024-10-01" \
+  --resume --verify --report html,json
+```
+
+## 7) Ajan Arayüzleri (Pseudo‑API)
+
+```ts
+// Auth & 2FA Agent
+interface AuthAgent {
+  login(appleId: string): Promise<{ requires2FA: boolean }>
+  submit2FA(code: string): Promise<{ trusted: boolean, sessionToken: string }>
+  loadSession(): Promise<Session | null>
+}
+
+// iCloud API Agent (resmi/özel mod)
+interface ICloudAgent {
+  listPhotos(params): Promise<Item[]>
+  listDrive(params): Promise<Item[]>
+  // private endpoints (gated)
+  listDeviceBackups(): Promise<BackupMeta[]> // may fail if not allowed
+  planDownload(backupId: string): Promise<Plan>
+  streamPart(plan: Plan, partIdx: number): AsyncIterable<ArrayBuffer>
+}
+
+// Download Manager
+interface Downloader {
+  run(plan: Plan, opts: { parallel: number, chunkMB: number }): Promise<Result>
+}
+
+// Crypto/Verify
+interface Verifier {
+  fileHash(path: string, algo: 'sha256'|'xxh3'): Promise<string>
+  verifyPlan(plan: Plan): Promise<Report>
+  decryptIfNeeded(plan: Plan, passphrase?: string): Promise<void>
+}
+```
+
+## 8) Hata Yönetimi & Geri Kazanım
+
+- **2FA süresi doldu** → tekrar kod iste, rate‑limit koruması.
+- **Quota yetersiz** → indirme başlamadan uyarı (threshold: %15 boş alan kuralı).
+- **Kısmi dosya** → checksum uyuşmazlığı → ilgili parçayı tekrar indir.
+- **Bağlantı koptu** → exponential backoff, en fazla N tekrar.
+- **Özel uç nokta kapandı** → kullanıcıya açıklama, resmi akışa düş.
+
+## 9) Test Stratejisi
+
+- **Dry‑run**: Sadece listeleme ve plan oluşturma; indirme yok.
+- **Simülasyon**: Sahte 2FA, sahte yedek listesi ile akış testi.
+- **Gerçek cihaz (USB)**: Küçük bir yerel yedek üstünde doğrulama.
+- **Büyük dosya**: Parçalı indirme ve resume testi (ağ kesintisi enjekte et).
+- **Hash/Decrypt**: Test vektörleri ile doğrulama.
+
+## 10) Yol Haritası
+
+- v0.1: Auth + USB yerel yedek liste/klon + rapor.
+- v0.2: iCloud Foto/Drive indirici (resmi erişim) + resume.
+- v0.3: (Gated) iCloud Device Backup meta keşfi, resmileşmeyen uç nokta kullanımı *opsiyonel*.
+- v0.4: Şifreli yedek parse/decrypt (kullanıcı parolasıyla), derin doğrulama.
+- v1.0: GUI, log/rapor iyileştirmeleri, çoklu cihaz desteği.
+
+## 11) Uyumluluk & Etik
+
+- Apple TOS ve yerel mevzuata uygunluk. Hesap güvenliğini tehlikeye atan yöntemler **varsayılan olarak kapalı**.
+- Kullanıcı verisi **uçtan uca şifreli** saklanmalı, minimum yetki prensibi.
+
+## 12) Sık Sorulanlar
+
+- **Gerçekten iCloud cihaz yedeklerini indirebilir miyim?**
+  - Resmi şekilde **doğrudan** değil. Yerel USB yedeği her zaman mümkün. iCloud tarafında ise resmi olarak **Foto/Drive** erişimi var. Cihaz yedeği için kullanılan özel uç noktalar kararsız/riskli olabilir.
+- **Neden 2FA bu kadar önemli?**
+  - Apple ekosistemi 2FA’yı zorunlu tutar; oturumun sürekliliği ve "trusted device" akışı bu yüzden kritik.
+
+---
+
+### Ekler
+
+- **Rapor Formatı (JSON):** `start/end`, `device`, `backup_id`, `files_ok/failed`, `hashes`, `duration`, `retries`.
+- **Log Formatı (JSONL):** her adım için `ts`, `level`, `event`, `ctx`.
+- **Dizin Düzeni:**
+
+```
+outputs/icloud_backups/
+  ├─ <device_name>_<date>/
+  │   ├─ manifest.json
+  │   ├─ files/...
+  │   └─ hashes/
+  └─ reports/
+      ├─ session_<ts>.json
+      └─ session_<ts>.html
+```
+

--- a/data/mock_icloud.json
+++ b/data/mock_icloud.json
@@ -1,0 +1,24 @@
+{
+  "photos": ["IMG_0001.JPG"],
+  "drive": ["Documents/report.pdf"],
+  "device_backups": [
+    {
+      "id": "demo-backup",
+      "device_name": "iPhone 13",
+      "created_at": "2024-01-01T12:00:00Z",
+      "approx_size_bytes": 2048,
+      "items": [
+        {
+          "logical_path": "files/info.txt",
+          "source_path": "fixtures/demo_backup/info.txt",
+          "size_bytes": 20
+        },
+        {
+          "logical_path": "config/config.json",
+          "source_path": "fixtures/demo_backup/config.json",
+          "size_bytes": 20
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/demo_backup/config.json
+++ b/fixtures/demo_backup/config.json
@@ -1,0 +1,1 @@
+{"setting": "value"}

--- a/fixtures/demo_backup/info.txt
+++ b/fixtures/demo_backup/info.txt
@@ -1,0 +1,1 @@
+Demo backup payload

--- a/macos-launcher.command
+++ b/macos-launcher.command
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "This launcher is intended for macOS. Detected: $(uname)."
+  exit 1
+fi
+
+export PIP_DISABLE_PIP_VERSION_CHECK=1
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
+VENV_DIR="$PROJECT_ROOT/.venv_macos"
+
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [[ -z "$PYTHON_BIN" ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python3)"
+  fi
+fi
+
+if [[ -z "$PYTHON_BIN" ]]; then
+  cat <<'MSG'
+[icloud-helper] python3 (3.11+) not found.
+Install it from https://www.python.org/downloads/mac-osx/ and rerun this launcher.
+MSG
+  read -r -p "Press Enter to close..." _
+  exit 1
+fi
+
+mkdir -p "$VENV_DIR"
+if [[ ! -d "$VENV_DIR/bin" ]]; then
+  echo "[icloud-helper] Creating virtual environment at $VENV_DIR"
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+echo "[icloud-helper] Ensuring dependencies are installed..."
+python -m pip install --upgrade pip setuptools wheel
+python -m pip install -e "$PROJECT_ROOT"
+
+echo "[icloud-helper] Launching GUI..."
+python -m icloud_multi_agent.gui "$@"
+
+EXIT_CODE=$?
+if [[ $EXIT_CODE -ne 0 ]]; then
+  echo "[icloud-helper] GUI exited with status $EXIT_CODE"
+fi
+
+read -r -p "Press Enter to close this window..." _
+exit $EXIT_CODE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "icloud-multi-agent"
+version = "0.1.0"
+description = "Mock multi-agent helper for exploring iCloud backup download workflows"
+authors = [{name = "OpenAI Codex"}]
+requires-python = ">=3.11"
+readme = "README.md"
+
+[project.scripts]
+icloud-helper = "icloud_multi_agent.cli:main"
+icloud-helper-gui = "icloud_multi_agent.gui:main"
+
+[tool.ruff]
+line-length = 100

--- a/src/icloud_multi_agent/__init__.py
+++ b/src/icloud_multi_agent/__init__.py
@@ -1,0 +1,1 @@
+"""Package exposing the mock iCloud multi-agent helpers."""

--- a/src/icloud_multi_agent/agents/__init__.py
+++ b/src/icloud_multi_agent/agents/__init__.py
@@ -1,0 +1,113 @@
+"""Agent interfaces for the iCloud backup helper."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Protocol
+
+
+@dataclass
+class Session:
+    """Represents an authenticated iCloud session."""
+
+    apple_id: str
+    session_token: str
+    trusted: bool
+
+
+class AuthAgent(Protocol):
+    """Authentication agent interface."""
+
+    def login(self, apple_id: str, password: Optional[str] | None = None) -> dict:
+        ...
+
+    def submit_2fa(self, code: str) -> Session:
+        ...
+
+    def load_session(self) -> Optional[Session]:
+        ...
+
+
+@dataclass
+class BackupMeta:
+    """Metadata describing a discovered backup."""
+
+    identifier: str
+    device_name: str
+    created_at: str
+    approx_size_bytes: int
+    source: str
+
+
+@dataclass
+class DownloadPlan:
+    """Concrete plan to download a backup."""
+
+    backup: BackupMeta
+    total_files: int
+    total_bytes: int
+    items: List["DownloadItem"]
+
+
+@dataclass
+class DownloadItem:
+    """Individual item that needs to be downloaded."""
+
+    logical_path: str
+    source_path: Path
+    size_bytes: int
+
+
+class ICloudAPI(Protocol):
+    """Interface for iCloud API access."""
+
+    def list_photos(self) -> Iterable[str]:
+        ...
+
+    def list_drive_items(self) -> Iterable[str]:
+        ...
+
+    def list_device_backups(self) -> List[BackupMeta]:
+        ...
+
+    def plan_download(self, backup_id: str, destination: Path) -> DownloadPlan:
+        ...
+
+
+class DownloadManager(Protocol):
+    def run(self, plan: DownloadPlan, destination: Path) -> "DownloadResult":
+        ...
+
+
+@dataclass
+class DownloadResult:
+    downloaded_bytes: int
+    downloaded_files: int
+    failed_items: List[DownloadItem]
+
+
+class Verifier(Protocol):
+    def verify(self, destination: Path, plan: DownloadPlan) -> "VerificationReport":
+        ...
+
+
+@dataclass
+class VerificationReport:
+    ok: bool
+    hashed_files: int
+    failed_files: List[str]
+
+
+class StorageManager(Protocol):
+    def ensure_capacity(self, required_bytes: int, destination: Path) -> None:
+        ...
+
+
+class IntegrityLog(Protocol):
+    def record(self, event: str, **context) -> None:
+        ...
+
+
+class ReportAgent(Protocol):
+    def export(self, destination: Path, plan: DownloadPlan, result: DownloadResult, verification: VerificationReport) -> Path:
+        ...

--- a/src/icloud_multi_agent/agents/auth_agent.py
+++ b/src/icloud_multi_agent/agents/auth_agent.py
@@ -1,0 +1,48 @@
+"""Simplified authentication agent with local session persistence."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from . import AuthAgent, Session
+
+
+_SESSION_FILE = Path.home() / ".icloud_session.json"
+
+
+@dataclass
+class LocalAuthAgent:
+    """A toy implementation storing session data locally."""
+
+    session_file: Path = _SESSION_FILE
+
+    def login(self, apple_id: str, password: Optional[str] | None = None) -> dict:
+        # In the real implementation we would start SRP login here. For now we
+        # simply persist the apple_id to the session file and pretend that 2FA
+        # is required.
+        if password is None or not password.strip():
+            raise ValueError("Apple ID parolası gerekli")
+        self.session_file.write_text(json.dumps({"apple_id": apple_id, "password_hint": "provided"}))
+        return {"requires2FA": True}
+
+    def submit_2fa(self, code: str) -> Session:
+        # Fake 2FA success and store a trusted session token.
+        data = json.loads(self.session_file.read_text())
+        session = Session(apple_id=data["apple_id"], session_token="mock-token", trusted=True)
+        self.session_file.write_text(
+            json.dumps({"apple_id": session.apple_id, "session_token": session.session_token, "trusted": True})
+        )
+        return session
+
+    def load_session(self) -> Optional[Session]:
+        if not self.session_file.exists():
+            return None
+        try:
+            raw = json.loads(self.session_file.read_text())
+        except json.JSONDecodeError:
+            return None
+        if "session_token" not in raw:
+            return None
+        return Session(apple_id=raw["apple_id"], session_token=raw["session_token"], trusted=raw.get("trusted", False))

--- a/src/icloud_multi_agent/agents/backup_indexer.py
+++ b/src/icloud_multi_agent/agents/backup_indexer.py
@@ -1,0 +1,15 @@
+"""Backup indexing agent."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from . import BackupMeta, ICloudAPI
+
+
+@dataclass
+class BackupIndexer:
+    api: ICloudAPI
+
+    def list_backups(self) -> List[BackupMeta]:
+        return self.api.list_device_backups()

--- a/src/icloud_multi_agent/agents/crypto_agent.py
+++ b/src/icloud_multi_agent/agents/crypto_agent.py
@@ -1,0 +1,37 @@
+"""Verifier agent performing hash validation."""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from ..config import SETTINGS
+from . import DownloadPlan, VerificationReport, Verifier
+
+
+@dataclass
+class HashVerifier(Verifier):
+    """Compute hashes for downloaded files."""
+
+    algorithm: str = SETTINGS.hash_algo
+
+    def _hash_file(self, path: Path) -> str:
+        hasher = hashlib.new(self.algorithm)
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                hasher.update(chunk)
+        return hasher.hexdigest()
+
+    def verify(self, destination: Path, plan: DownloadPlan) -> VerificationReport:
+        failed: List[str] = []
+        hashed = 0
+        for item in plan.items:
+            target = destination / item.logical_path
+            if not target.exists():
+                failed.append(item.logical_path)
+                continue
+            hashed += 1
+            # In the mock scenario we do not have expected hashes; simply compute.
+            self._hash_file(target)
+        return VerificationReport(ok=not failed, hashed_files=hashed, failed_files=failed)

--- a/src/icloud_multi_agent/agents/download_manager.py
+++ b/src/icloud_multi_agent/agents/download_manager.py
@@ -1,0 +1,42 @@
+"""Download manager implementing chunked copy for local sources."""
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..config import SETTINGS
+from . import DownloadManager as DownloadManagerProtocol, DownloadPlan, DownloadResult
+
+
+@dataclass
+class LocalDownloadManager(DownloadManagerProtocol):
+    """Download manager copying files from local paths."""
+
+    chunk_size: int = SETTINGS.chunk_size_bytes
+
+    def _copy_file(self, source: Path, destination: Path) -> int:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        bytes_written = 0
+        with source.open("rb") as src, destination.open("wb") as dst:
+            while True:
+                chunk = src.read(self.chunk_size)
+                if not chunk:
+                    break
+                dst.write(chunk)
+                bytes_written += len(chunk)
+        shutil.copystat(source, destination, follow_symlinks=True)
+        return bytes_written
+
+    def run(self, plan: DownloadPlan, destination: Path) -> DownloadResult:
+        downloaded_bytes = 0
+        downloaded_files = 0
+        failed_items = []
+        for item in plan.items:
+            target = destination / item.logical_path
+            try:
+                downloaded_bytes += self._copy_file(item.source_path, target)
+                downloaded_files += 1
+            except (FileNotFoundError, OSError):
+                failed_items.append(item)
+        return DownloadResult(downloaded_bytes=downloaded_bytes, downloaded_files=downloaded_files, failed_items=failed_items)

--- a/src/icloud_multi_agent/agents/icloud_api_agent.py
+++ b/src/icloud_multi_agent/agents/icloud_api_agent.py
@@ -1,0 +1,77 @@
+"""Simplified iCloud API agent with a mock data source."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+from ..policy import PolicyGate
+from . import BackupMeta, DownloadItem, DownloadPlan, ICloudAPI
+
+
+@dataclass
+class MockICloudAPI(ICloudAPI):
+    """A mock implementation backed by JSON fixtures on disk."""
+
+    data_file: Path
+    policy: PolicyGate
+
+    def _load_data(self) -> dict:
+        if not self.data_file.exists():
+            return {"photos": [], "drive": [], "device_backups": []}
+        return json.loads(self.data_file.read_text())
+
+    def list_photos(self) -> Iterable[str]:
+        return self._load_data().get("photos", [])
+
+    def list_drive_items(self) -> Iterable[str]:
+        return self._load_data().get("drive", [])
+
+    def list_device_backups(self) -> List[BackupMeta]:
+        self.policy.require_private_access("device_backups")
+        backups = []
+        for entry in self._load_data().get("device_backups", []):
+            backups.append(
+                BackupMeta(
+                    identifier=entry["id"],
+                    device_name=entry["device_name"],
+                    created_at=entry["created_at"],
+                    approx_size_bytes=entry.get("approx_size_bytes", 0),
+                    source="icloud",
+                )
+            )
+        return backups
+
+    def plan_download(self, backup_id: str, destination: Path) -> DownloadPlan:
+        self.policy.require_private_access("device_backups")
+        data = self._load_data()
+        matches = [b for b in data.get("device_backups", []) if b["id"] == backup_id]
+        if not matches:
+            raise FileNotFoundError(f"Backup {backup_id} not found in mock data")
+        backup = matches[0]
+        items: List[DownloadItem] = []
+        total_bytes = 0
+        for item in backup.get("items", []):
+            source_path = Path(item["source_path"])
+            size = int(item.get("size_bytes", source_path.stat().st_size if source_path.exists() else 0))
+            total_bytes += size
+            items.append(
+                DownloadItem(
+                    logical_path=item["logical_path"],
+                    source_path=source_path,
+                    size_bytes=size,
+                )
+            )
+        return DownloadPlan(
+            backup=BackupMeta(
+                identifier=backup["id"],
+                device_name=backup["device_name"],
+                created_at=backup["created_at"],
+                approx_size_bytes=backup.get("approx_size_bytes", total_bytes),
+                source="icloud",
+            ),
+            total_files=len(items),
+            total_bytes=total_bytes,
+            items=items,
+        )

--- a/src/icloud_multi_agent/agents/integrity_log.py
+++ b/src/icloud_multi_agent/agents/integrity_log.py
@@ -1,0 +1,31 @@
+"""Integrity log agent writing JSON lines."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+from . import IntegrityLog
+
+
+@dataclass
+class JsonlIntegrityLog(IntegrityLog):
+    log_file: Path
+    _file_handle: Any = field(init=False, repr=False, default=None)
+
+    def _ensure_handle(self) -> None:
+        if self._file_handle is None:
+            self.log_file.parent.mkdir(parents=True, exist_ok=True)
+            self._file_handle = self.log_file.open("a", encoding="utf-8")
+
+    def record(self, event: str, **context: Dict[str, Any]) -> None:
+        self._ensure_handle()
+        entry = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "event": event,
+            "context": context,
+        }
+        self._file_handle.write(json.dumps(entry) + "\n")
+        self._file_handle.flush()

--- a/src/icloud_multi_agent/agents/report_agent.py
+++ b/src/icloud_multi_agent/agents/report_agent.py
@@ -1,0 +1,36 @@
+"""Report exporting agent."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from . import DownloadPlan, DownloadResult, ReportAgent as ReportAgentProtocol, VerificationReport
+
+
+@dataclass
+class JsonReportAgent(ReportAgentProtocol):
+    reports_dir: Path
+
+    def export(
+        self, destination: Path, plan: DownloadPlan, result: DownloadResult, verification: VerificationReport
+    ) -> Path:
+        self.reports_dir.mkdir(parents=True, exist_ok=True)
+        report_path = self.reports_dir / f"session_{datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')}.json"
+        report = {
+            "backup": plan.backup.__dict__,
+            "destination": str(destination),
+            "download": {
+                "files": result.downloaded_files,
+                "bytes": result.downloaded_bytes,
+                "failed": [item.logical_path for item in result.failed_items],
+            },
+            "verification": {
+                "ok": verification.ok,
+                "hashed_files": verification.hashed_files,
+                "failed_files": verification.failed_files,
+            },
+        }
+        report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        return report_path

--- a/src/icloud_multi_agent/agents/storage_manager.py
+++ b/src/icloud_multi_agent/agents/storage_manager.py
@@ -1,0 +1,23 @@
+"""Storage quota checks."""
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import StorageManager
+
+
+@dataclass
+class DiskStorageManager(StorageManager):
+    safety_ratio: float = 0.15
+
+    def ensure_capacity(self, required_bytes: int, destination: Path) -> None:
+        destination.mkdir(parents=True, exist_ok=True)
+        usage = shutil.disk_usage(destination)
+        free_after = usage.free - required_bytes
+        if free_after < 0 or free_after < usage.total * self.safety_ratio:
+            raise OSError(
+                "Insufficient disk space for download. "
+                f"Required: {required_bytes}, Available: {usage.free}, Safety ratio: {self.safety_ratio:.0%}."
+            )

--- a/src/icloud_multi_agent/cli.py
+++ b/src/icloud_multi_agent/cli.py
@@ -1,0 +1,129 @@
+"""Command line interface for the iCloud multi-agent helper."""
+from __future__ import annotations
+
+import argparse
+import getpass
+from pathlib import Path
+from typing import Optional
+
+from .agents.auth_agent import LocalAuthAgent
+from .agents.backup_indexer import BackupIndexer
+from .agents.crypto_agent import HashVerifier
+from .agents.download_manager import LocalDownloadManager
+from .agents.icloud_api_agent import MockICloudAPI
+from .agents.integrity_log import JsonlIntegrityLog
+from .agents.report_agent import JsonReportAgent
+from .agents.storage_manager import DiskStorageManager
+from .config import SETTINGS
+from .orchestrator import Orchestrator
+from .policy import PolicyGate
+
+DEFAULT_DATA_FILE = Path("data/mock_icloud.json")
+DEFAULT_LOG_FILE = Path("outputs/logs/session.jsonl")
+DEFAULT_REPORT_DIR = Path("outputs/icloud_backups/reports")
+
+
+def build_orchestrator(allow_private: bool, data_file: Path) -> Orchestrator:
+    policy = PolicyGate(allow_private_endpoints=allow_private)
+    api = MockICloudAPI(data_file=data_file, policy=policy)
+    indexer = BackupIndexer(api=api)
+    downloader = LocalDownloadManager()
+    verifier = HashVerifier()
+    storage = DiskStorageManager()
+    integrity = JsonlIntegrityLog(log_file=DEFAULT_LOG_FILE)
+    reporter = JsonReportAgent(reports_dir=DEFAULT_REPORT_DIR)
+    orchestrator = Orchestrator(
+        auth=LocalAuthAgent(),
+        api=api,
+        indexer=indexer,
+        downloader=downloader,
+        verifier=verifier,
+        storage=storage,
+        integrity_log=integrity,
+        reporter=reporter,
+        policy=policy,
+    )
+    return orchestrator
+
+
+def cmd_auth_login(orchestrator: Orchestrator, args: argparse.Namespace) -> None:
+    password = args.password
+    if password is None:
+        password = getpass.getpass("Apple ID password: ")
+    session = orchestrator.ensure_session(
+        apple_id=args.apple_id,
+        password=password,
+        two_factor_code=args.code,
+    )
+    print(f"Trusted session for {session.apple_id} (token: {session.session_token})")
+
+
+def cmd_backup_list(orchestrator: Orchestrator, args: argparse.Namespace) -> None:
+    backups = orchestrator.list_backups()
+    if not backups:
+        print("No backups available under current policy.")
+        return
+    for identifier, device_name, created_at, approx_size in backups:
+        print(f"{identifier}\t{device_name}\t{created_at}\t{approx_size} bytes")
+
+
+def cmd_backup_plan(orchestrator: Orchestrator, args: argparse.Namespace) -> None:
+    device_name, total_files, total_bytes = orchestrator.plan(args.id, Path(args.dest))
+    print(f"Backup {args.id} ({device_name}) -> {total_files} files, {total_bytes} bytes")
+
+
+def cmd_backup_download(orchestrator: Orchestrator, args: argparse.Namespace) -> None:
+    destination = Path(args.dest)
+    plan, result, verification, report = orchestrator.download(args.id, destination)
+    print(f"Downloaded {result.downloaded_files}/{plan.total_files} files to {destination}")
+    print(f"Verification {'OK' if verification.ok else 'FAILED'}")
+    print(f"Report saved to {report}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="iCloud backup helper (mock implementation)")
+    parser.add_argument("--data-file", default=DEFAULT_DATA_FILE, type=Path, help="Mock data JSON path")
+    parser.add_argument(
+        "--allow-private",
+        action="store_true",
+        default=SETTINGS.allow_private_endpoints,
+        help="Enable private iCloud backup inspection (requires risk acknowledgement)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    auth_login = subparsers.add_parser("auth-login", help="Authenticate with Apple ID")
+    auth_login.add_argument("--apple-id", required=True)
+    auth_login.add_argument("--password", required=False, help="Apple ID password (prompted if omitted)")
+    auth_login.add_argument("--code", required=False, help="2FA code (otherwise prompted)")
+    auth_login.set_defaults(func=cmd_auth_login)
+
+    backup_list = subparsers.add_parser("backup-list", help="List available backups")
+    backup_list.set_defaults(func=cmd_backup_list)
+
+    backup_plan = subparsers.add_parser("backup-plan", help="Summarise a backup before download")
+    backup_plan.add_argument("--id", required=True)
+    backup_plan.add_argument("--dest", default=str(SETTINGS.download_dir))
+    backup_plan.set_defaults(func=cmd_backup_plan)
+
+    backup_download = subparsers.add_parser("backup-download", help="Download a backup")
+    backup_download.add_argument("--id", required=True)
+    backup_download.add_argument("--dest", default=str(SETTINGS.download_dir))
+    backup_download.set_defaults(func=cmd_backup_download)
+
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    orchestrator = build_orchestrator(allow_private=args.allow_private, data_file=args.data_file)
+    try:
+        args.func(orchestrator, args)
+    except Exception as exc:  # noqa: BLE001 - CLI surface should show errors
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/icloud_multi_agent/config.py
+++ b/src/icloud_multi_agent/config.py
@@ -1,0 +1,30 @@
+"""Configuration helpers for the iCloud multi-agent tool."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Runtime configuration derived from environment variables."""
+
+    download_dir: Path = Path(os.getenv("DOWNLOAD_DIR", "./outputs/icloud_backups")).expanduser()
+    chunk_size_mb: int = int(os.getenv("CHUNK_SIZE_MB", "16"))
+    max_parallel: int = int(os.getenv("MAX_PARALLEL", "4"))
+    hash_algo: str = os.getenv("HASH_ALGO", "sha256")
+    allow_private_endpoints: bool = os.getenv("ALLOW_PRIVATE_ENDPOINTS", "false").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    log_level: str = os.getenv("LOG_LEVEL", "INFO")
+
+    @property
+    def chunk_size_bytes(self) -> int:
+        return self.chunk_size_mb * 1024 * 1024
+
+
+SETTINGS = Settings()

--- a/src/icloud_multi_agent/gui.py
+++ b/src/icloud_multi_agent/gui.py
@@ -1,0 +1,276 @@
+"""Simple Tkinter GUI for interacting with the mock iCloud helper."""
+from __future__ import annotations
+
+import threading
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, simpledialog, ttk
+from typing import Optional
+
+from .cli import DEFAULT_DATA_FILE, build_orchestrator
+from .config import SETTINGS
+
+
+class BackupGUI:
+    """Graphical interface that wraps the orchestrator workflow."""
+
+    def __init__(self) -> None:
+        self.root = tk.Tk()
+        self.root.title("Mock iCloud Backup Helper")
+        self.root.geometry("720x520")
+
+        self.apple_id_var = tk.StringVar()
+        self.password_var = tk.StringVar()
+        self.code_var = tk.StringVar()
+        self.allow_private_var = tk.BooleanVar(value=SETTINGS.allow_private_endpoints)
+        self.data_file_var = tk.StringVar(value=str(DEFAULT_DATA_FILE))
+        self.status_var = tk.StringVar(value="Hazır.")
+
+        self._backups: list[tuple[str, str, str, int]] = []
+        self._orchestrator = None
+        self._cached_allow_private: Optional[bool] = None
+        self._cached_data_file: Optional[Path] = None
+        self._lock = threading.Lock()
+
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # UI construction helpers
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        padding = {"padx": 10, "pady": 5}
+
+        config_frame = ttk.LabelFrame(self.root, text="Ayarlar")
+        config_frame.pack(fill=tk.X, padx=10, pady=10)
+
+        ttk.Label(config_frame, text="Veri dosyası:").grid(row=0, column=0, sticky=tk.W, **padding)
+        data_entry = ttk.Entry(config_frame, textvariable=self.data_file_var, width=60)
+        data_entry.grid(row=0, column=1, sticky=tk.W, **padding)
+        ttk.Button(config_frame, text="Seç...", command=self._select_data_file).grid(row=0, column=2, **padding)
+        ttk.Checkbutton(
+            config_frame,
+            text="Özel uç noktalara izin ver (riskli)",
+            variable=self.allow_private_var,
+            command=self._invalidate_orchestrator,
+        ).grid(row=1, column=1, sticky=tk.W, **padding)
+
+        config_frame.columnconfigure(1, weight=1)
+
+        auth_frame = ttk.LabelFrame(self.root, text="Kimlik Doğrulama")
+        auth_frame.pack(fill=tk.X, padx=10, pady=5)
+
+        ttk.Label(auth_frame, text="Apple ID:").grid(row=0, column=0, sticky=tk.W, **padding)
+        ttk.Entry(auth_frame, textvariable=self.apple_id_var, width=30).grid(row=0, column=1, **padding)
+        ttk.Label(auth_frame, text="Parola:").grid(row=0, column=2, sticky=tk.W, **padding)
+        ttk.Entry(auth_frame, textvariable=self.password_var, show="*", width=18).grid(row=0, column=3, **padding)
+        ttk.Button(auth_frame, text="Giriş Yap", command=self.on_login).grid(row=0, column=4, rowspan=2, **padding)
+        ttk.Label(auth_frame, text="2FA Kodu:").grid(row=1, column=0, sticky=tk.W, **padding)
+        ttk.Entry(auth_frame, textvariable=self.code_var, width=12).grid(row=1, column=1, sticky=tk.W, **padding)
+
+        auth_frame.columnconfigure(1, weight=1)
+
+        backup_frame = ttk.LabelFrame(self.root, text="Yedekler")
+        backup_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
+
+        list_container = ttk.Frame(backup_frame)
+        list_container.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        self.backup_list = tk.Listbox(list_container, height=10)
+        scrollbar = ttk.Scrollbar(list_container, orient=tk.VERTICAL, command=self.backup_list.yview)
+        self.backup_list.configure(yscrollcommand=scrollbar.set)
+        self.backup_list.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+
+        button_frame = ttk.Frame(backup_frame)
+        button_frame.pack(fill=tk.X, padx=5, pady=5)
+
+        ttk.Button(button_frame, text="Yedekleri Yenile", command=self.on_refresh_backups).pack(side=tk.LEFT, padx=5)
+        ttk.Button(button_frame, text="Seçili Yedeği İndir", command=self.on_download_backup).pack(side=tk.LEFT, padx=5)
+
+        status_frame = ttk.Frame(self.root)
+        status_frame.pack(fill=tk.X, padx=10, pady=5)
+        ttk.Label(status_frame, textvariable=self.status_var).pack(anchor=tk.W)
+
+        log_frame = ttk.LabelFrame(self.root, text="Günlük")
+        log_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
+        self.log_text = tk.Text(log_frame, height=10, state="disabled")
+        self.log_text.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+    # ------------------------------------------------------------------
+    # Orchestrator helpers
+    # ------------------------------------------------------------------
+    def _select_data_file(self) -> None:
+        selection = filedialog.askopenfilename(
+            title="Mock verisini seç",
+            initialdir=str(Path(self.data_file_var.get()).expanduser().parent),
+            filetypes=[("JSON", "*.json"), ("Tümü", "*.*")],
+        )
+        if selection:
+            self.data_file_var.set(selection)
+            self._invalidate_orchestrator()
+
+    def _invalidate_orchestrator(self) -> None:
+        with self._lock:
+            self._orchestrator = None
+            self._cached_allow_private = None
+            self._cached_data_file = None
+        self.log("Yapılandırma değişti, ajanlar yeniden oluşturulacak.")
+
+    def _get_orchestrator(self):
+        allow_private = self.allow_private_var.get()
+        data_file = Path(self.data_file_var.get()).expanduser()
+        with self._lock:
+            needs_rebuild = (
+                self._orchestrator is None
+                or allow_private != self._cached_allow_private
+                or data_file != self._cached_data_file
+            )
+            if needs_rebuild:
+                self.log("Ajanlar hazırlanıyor...")
+                self._orchestrator = build_orchestrator(allow_private=allow_private, data_file=data_file)
+                self._cached_allow_private = allow_private
+                self._cached_data_file = data_file
+        return self._orchestrator
+
+    # ------------------------------------------------------------------
+    # Utility methods
+    # ------------------------------------------------------------------
+    def log(self, message: str) -> None:
+        def append() -> None:
+            self.log_text.configure(state="normal")
+            self.log_text.insert("end", message + "\n")
+            self.log_text.see("end")
+            self.log_text.configure(state="disabled")
+            self.status_var.set(message)
+
+        self.root.after(0, append)
+
+    def handle_error(self, error: Exception) -> None:
+        self.log(f"Hata: {error}")
+        messagebox.showerror("Hata", str(error))
+
+    def run_async(self, worker, on_success=None) -> None:
+        def target() -> None:
+            try:
+                result = worker()
+            except Exception as exc:  # noqa: BLE001 - kullanıcıya hata gösterilecek
+                self.root.after(0, lambda: self.handle_error(exc))
+                return
+            if on_success:
+                self.root.after(0, lambda: on_success(result))
+
+        threading.Thread(target=target, daemon=True).start()
+
+    @staticmethod
+    def _format_size(num_bytes: int) -> str:
+        step = 1024.0
+        units = ["B", "KB", "MB", "GB", "TB"]
+        value = float(num_bytes)
+        for unit in units:
+            if value < step:
+                return f"{value:.1f} {unit}" if unit != "B" else f"{int(value)} {unit}"
+            value /= step
+        return f"{value:.1f} PB"
+
+    def _update_backup_list(self, backups: list[tuple[str, str, str, int]]) -> None:
+        self._backups = backups
+        self.backup_list.delete(0, tk.END)
+        if not backups:
+            self.backup_list.insert(tk.END, "Yedek bulunamadı")
+            self.status_var.set("Yedek bulunamadı")
+            return
+        for identifier, device, created_at, approx_size in backups:
+            human_size = self._format_size(approx_size)
+            display = f"{device} · {created_at} · {human_size} · ID: {identifier}"
+            self.backup_list.insert(tk.END, display)
+        self.status_var.set(f"{len(backups)} yedek listelendi")
+
+    # ------------------------------------------------------------------
+    # Command callbacks
+    # ------------------------------------------------------------------
+    def on_login(self) -> None:
+        apple_id = self.apple_id_var.get().strip()
+        if not apple_id:
+            messagebox.showwarning("Eksik bilgi", "Apple ID girin")
+            return
+        password = self.password_var.get()
+        if not password:
+            messagebox.showwarning("Eksik bilgi", "Parolayı girin")
+            return
+        code = self.code_var.get().strip()
+        if not code:
+            code = simpledialog.askstring("2FA", "2FA kodunu girin:", parent=self.root)
+            if not code:
+                return
+
+        def worker():
+            orchestrator = self._get_orchestrator()
+            return orchestrator.ensure_session(apple_id=apple_id, password=password, two_factor_code=code)
+
+        def on_success(session):
+            self.password_var.set("")
+            self.log(f"{session.apple_id} için güvenilen oturum oluşturuldu.")
+            messagebox.showinfo("Başarılı", f"Oturum belirteci: {session.session_token}")
+
+        self.run_async(worker, on_success)
+
+    def on_refresh_backups(self) -> None:
+        def worker():
+            orchestrator = self._get_orchestrator()
+            return orchestrator.list_backups()
+
+        def on_success(backups):
+            self.log("Yedek listesi güncellendi.")
+            self._update_backup_list(backups)
+
+        self.run_async(worker, on_success)
+
+    def on_download_backup(self) -> None:
+        if not self._backups:
+            messagebox.showwarning("Yedek yok", "Önce yedek listesini yenileyin")
+            return
+        selection = self.backup_list.curselection()
+        if not selection:
+            messagebox.showwarning("Seçim yok", "İndirilecek yedeği seçin")
+            return
+        backup = self._backups[selection[0]]
+        identifier, device_name, created_at, _ = backup
+
+        destination_dir = filedialog.askdirectory(
+            title="İndirme klasörünü seç",
+            initialdir=str(SETTINGS.download_dir.expanduser()),
+        )
+        if not destination_dir:
+            return
+        final_destination = Path(destination_dir) / f"{identifier}"
+
+        def worker():
+            orchestrator = self._get_orchestrator()
+            plan, result, verification, report = orchestrator.download(identifier, final_destination)
+            return plan, result, verification, report
+
+        def on_success(result_tuple):
+            plan, result, verification, report = result_tuple
+            message = (
+                f"{device_name} ({created_at}) yedeği {final_destination} klasörüne indirildi. "
+                f"{result.downloaded_files}/{plan.total_files} dosya, durum: "
+                f"{'OK' if verification.ok else 'HATALI'}"
+            )
+            self.log(message)
+            messagebox.showinfo("İndirme tamamlandı", f"Rapor: {report}")
+
+        self.run_async(worker, on_success)
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        self.root.mainloop()
+
+
+def main() -> int:
+    app = BackupGUI()
+    app.run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/icloud_multi_agent/orchestrator.py
+++ b/src/icloud_multi_agent/orchestrator.py
@@ -1,0 +1,83 @@
+"""High level orchestrator for the multi-agent workflow."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .agents import AuthAgent, DownloadManager, ICloudAPI, IntegrityLog, ReportAgent, Session, StorageManager, Verifier
+from .agents.backup_indexer import BackupIndexer
+from .policy import PolicyGate
+
+
+@dataclass
+class Orchestrator:
+    auth: AuthAgent
+    api: ICloudAPI
+    indexer: BackupIndexer
+    downloader: DownloadManager
+    verifier: Verifier
+    storage: StorageManager
+    integrity_log: IntegrityLog
+    reporter: ReportAgent
+    policy: PolicyGate
+
+    def ensure_session(
+        self,
+        apple_id: Optional[str],
+        password: Optional[str] = None,
+        two_factor_code: Optional[str] = None,
+    ) -> Session:
+        session = self.auth.load_session()
+        if session:
+            return session
+        if not apple_id:
+            raise ValueError("Apple ID must be provided when no trusted session exists")
+        if password is None or not password.strip():
+            raise ValueError("Apple ID password must be provided when no trusted session exists")
+        login_result = self.auth.login(apple_id, password)
+        if not login_result.get("requires2FA"):
+            raise RuntimeError("Unexpected login flow; mock implementation always requires 2FA")
+        code = two_factor_code or input("Enter 2FA code: ")
+        session = self.auth.submit_2fa(code)
+        self.integrity_log.record("auth", status="trusted" if session.trusted else "untrusted")
+        for capability in self.policy.describe_capabilities():
+            self.integrity_log.record("policy", capability=capability)
+        return session
+
+    def list_backups(self) -> list[tuple[str, str, str, int]]:
+        backups = self.indexer.list_backups()
+        return [
+            (
+                backup.identifier,
+                backup.device_name,
+                backup.created_at,
+                backup.approx_size_bytes,
+            )
+            for backup in backups
+        ]
+
+    def plan(self, backup_id: str, destination: Path) -> tuple[str, int, int]:
+        plan = self.api.plan_download(backup_id, destination)
+        return plan.backup.device_name, plan.total_files, plan.total_bytes
+
+    def download(self, backup_id: str, destination: Path):
+        plan = self.api.plan_download(backup_id, destination)
+        self.storage.ensure_capacity(plan.total_bytes, destination)
+        self.integrity_log.record(
+            "download_start",
+            backup_id=backup_id,
+            files=plan.total_files,
+            bytes=plan.total_bytes,
+        )
+        result = self.downloader.run(plan, destination)
+        verification = self.verifier.verify(destination, plan)
+        self.integrity_log.record(
+            "download_complete",
+            backup_id=backup_id,
+            downloaded_bytes=result.downloaded_bytes,
+            downloaded_files=result.downloaded_files,
+            verification_ok=verification.ok,
+        )
+        report = self.reporter.export(destination, plan, result, verification)
+        return plan, result, verification, report

--- a/src/icloud_multi_agent/policy.py
+++ b/src/icloud_multi_agent/policy.py
@@ -1,0 +1,31 @@
+"""Policy gate helpers to ensure private endpoints remain opt-in."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+class PolicyViolation(RuntimeError):
+    """Raised when an operation violates the configured policy."""
+
+
+@dataclass
+class PolicyGate:
+    """Simple helper encapsulating whether gated operations are allowed."""
+
+    allow_private_endpoints: bool
+
+    def require_private_access(self, capability: str) -> None:
+        """Ensure the caller explicitly enabled private endpoints."""
+
+        if not self.allow_private_endpoints:
+            raise PolicyViolation(
+                "Private iCloud backup endpoints are disabled. "
+                "Set ALLOW_PRIVATE_ENDPOINTS=true to opt-in after acknowledging the risk."
+            )
+
+    def describe_capabilities(self) -> Iterable[str]:
+        if self.allow_private_endpoints:
+            yield "Private iCloud device backup inspection is ENABLED."
+        else:
+            yield "Private iCloud device backup inspection is DISABLED by policy."


### PR DESCRIPTION
## Summary
- require an Apple ID password when establishing a session and pass it through the orchestrator and auth agent
- extend the CLI and GUI to collect the password (with a masked field) and refresh documentation accordingly

## Testing
- `python -m compileall src`


------
https://chatgpt.com/codex/tasks/task_e_68e54243163c83248b97d9db53f778aa