### PR TITLE
Validate 2FA input before creating a session

### DIFF
--- a/src/icloud_multi_agent/agents/auth_agent.py
+++ b/src/icloud_multi_agent/agents/auth_agent.py
@@ -29,6 +29,13 @@ class LocalAuthAgent:
 
     def submit_2fa(self, code: str) -> Session:
         # Fake 2FA success and store a trusted session token.
+        normalized = code.strip()
+        if len(normalized) != 6 or not normalized.isdigit():
+            # Temiz bir durumla çıkmak için oturum dosyasını sil.
+            if self.session_file.exists():
+                self.session_file.unlink()
+            raise ValueError("Geçersiz 2FA kodu girildi, işlem sonlandırılıyor")
+
         data = json.loads(self.session_file.read_text())
         session = Session(apple_id=data["apple_id"], session_token="mock-token", trusted=True)
         self.session_file.write_text(


### PR DESCRIPTION
## Summary
- ensure the mock auth agent rejects malformed 2FA codes
- clean up the temporary session file before exiting on invalid 2FA input

## Testing
- PYTHONPATH=src python -m icloud_multi_agent.cli auth-login --apple-id test@example.com --password secret --code 123
- PYTHONPATH=src python -m icloud_multi_agent.cli auth-login --apple-id test@example.com --password secret --code 123456
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e55479416083248dcd57a9e1d0c90b